### PR TITLE
cache stringmetrics

### DIFF
--- a/R/primitives.R
+++ b/R/primitives.R
@@ -1398,28 +1398,56 @@ yDetails.text <- function(x, theta) {
     unit(bounds[2L], "inches")
 }
 
-widthDetails.text <- function(x) {
-  bounds <- grid.Call(C_textBounds, as.graphicsAnnot(x$label),
-                      x$x, x$y,
-                      resolveHJust(x$just, x$hjust),
-                      resolveVJust(x$just, x$vjust),
-                      x$rot, 0)
-  if (is.null(bounds))
-    unit(0, "inches")
-  else
-    unit(bounds[3L], "inches")
+text_key <- function(grob, width = FALSE) {
+  cur_dev <- names(grDevices::dev.cur())
+  gp <- unclass(grob$gp)
+  key <- paste0(cur_dev, ':', gp$fontfamily, ':', gp$fontface, ":", gp$fontsize, ":", gp$cex, ":", gp$lineheight)
+  if ((width && !grob$rot %in% c(90, 270)) ||
+      (!width && !grob$rot %in% c(0, 180))) {
+    key <- paste0(grob$label[1], ":", grob$rot, ":", key) # C_textBounds ignores all but the first label
+  } else {
+    n_lines <- length(gregexpr('\n', grob$label, fixed = TRUE)[[1]])
+    key <- paste0(n_lines, "<>", key)
+  }
+  key
 }
 
+width_cache <- new.env(parent = emptyenv())
+widthDetails.text <- function(x) {
+  key <- text_key(x, TRUE)
+  bounds <- width_cache[[key]]
+  if (is.null(bounds)) {
+    bounds <- grid.Call(C_textBounds, as.graphicsAnnot(x$label),
+                        x$x, x$y,
+                        resolveHJust(x$just, x$hjust),
+                        resolveVJust(x$just, x$vjust),
+                        x$rot, 0)
+    bounds <- if (is.null(bounds))
+      unit(0, "inches")
+    else
+      unit(bounds[3L], "inches")
+    width_cache[[key]] <- bounds
+  }
+  bounds
+}
+
+height_cache <- new.env(parent = emptyenv())
 heightDetails.text <- function(x) {
-  bounds <- grid.Call(C_textBounds, as.graphicsAnnot(x$label),
-                      x$x, x$y,
-                      resolveHJust(x$just, x$hjust),
-                      resolveVJust(x$just, x$vjust),
-                      x$rot, 0)
-  if (is.null(bounds))
-    unit(0, "inches")
-  else
-    unit(bounds[4L], "inches")
+  key <- text_key(x, FALSE)
+  bounds <- height_cache[[key]]
+  if (is.null(bounds)) {
+    bounds <- grid.Call(C_textBounds, as.graphicsAnnot(x$label),
+                        x$x, x$y,
+                        resolveHJust(x$just, x$hjust),
+                        resolveVJust(x$just, x$vjust),
+                        x$rot, 0)
+    bounds <- if (is.null(bounds))
+      unit(0, "inches")
+    else
+      unit(bounds[4L], "inches")
+    height_cache[[key]] <- bounds
+  }
+  bounds
 }
 
 ascentDetails.text <- function(x) {


### PR DESCRIPTION
Calculating textgrob dimensions is one of the bigger single bottlenecks of grid, and one that is ripe for caching. This is a POC for such a caching, and should more be intended as a starting point for a discussion. In general I think this is better delegated to C-code as it can better figure out the exact graphic parameters at draw time.

An alternative is of course to speed up calculation of stringmetrics somehow, but I'm unsure why it is so slow. My best guess is that it is because it has to push and pop viewports in order to draw the grob and calculate the metrics. If so, this is not easily solved... maybe @pmur002 has some insight?

In any case, @pmur002, I would like to discuss if this is something you are open to solving either through caching/memoisation or some other way...