### PR TITLE
Cache primitives

### DIFF
--- a/src/grid.c
+++ b/src/grid.c
@@ -3423,7 +3423,13 @@ SEXP L_points(SEXP x, SEXP y, SEXP pch, SEXP size)
     initGContext(currentgp, &gc, dd, gpIsScalar, &gcCache);
     nx = unitLength(x); 
     npch = LENGTH(pch);
-    nss = unitLength(size);
+    /*
+     * Need to take vector gpar elements into account that may affect unit size 
+     * calculations
+     */
+    nss = unitLength(size) * LENGTH(VECTOR_ELT(currentgp, GP_FONTSIZE)) * 
+        LENGTH(VECTOR_ELT(currentgp, GP_CEX)) * 
+        LENGTH(VECTOR_ELT(currentgp, GP_LINEHEIGHT));
     /* Convert the x and y values to CM locations */
     vmax = vmaxget();
     xx = (double *) R_alloc(nx, sizeof(double));
@@ -3442,6 +3448,7 @@ SEXP L_points(SEXP x, SEXP y, SEXP pch, SEXP size)
     }
     ss = (double *) R_alloc(nss, sizeof(double));
     for (i=0; i < nss; i++) {
+        updateGContext(currentgp, i, &gc, dd, gpIsScalar, &gcCache);
         ss[i] = transformWidthtoINCHES(size, i, vpc, &gc,
                                        vpWidthCM, vpHeightCM, dd);
         ss[i] = toDeviceWidth(ss[i], GE_INCHES, dd);

--- a/src/grid.c
+++ b/src/grid.c
@@ -3445,6 +3445,7 @@ SEXP L_points(SEXP x, SEXP y, SEXP pch, SEXP size)
     nss = unitLength(size) * LENGTH(VECTOR_ELT(currentgp, GP_FONTSIZE)) * 
         LENGTH(VECTOR_ELT(currentgp, GP_CEX)) * 
         LENGTH(VECTOR_ELT(currentgp, GP_LINEHEIGHT));
+    nss = nss > nx ? nx : nss;
     /* Convert the x and y values to CM locations */
     vmax = vmaxget();
     xx = (double *) R_alloc(nx, sizeof(double));

--- a/src/grid.c
+++ b/src/grid.c
@@ -1097,8 +1097,9 @@ SEXP L_convert(SEXP x, SEXP whatfrom,
     SEXP answer;
     double vpWidthCM, vpHeightCM;
     double rotationAngle;
+    int gpIsScalar[15] = {-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1};
     LViewportContext vpc;
-    R_GE_gcontext gc;
+    R_GE_gcontext gc, gcCache;
     LTransform transform;
     SEXP currentvp, currentgp;
     int TOunit, FROMaxis, TOaxis;
@@ -1118,10 +1119,11 @@ SEXP L_convert(SEXP x, SEXP whatfrom,
 			 &vpWidthCM, &vpHeightCM, 
 			 transform, &rotationAngle);
     getViewportContext(currentvp, &vpc);
+    initGContext(currentgp, &gc, dd, gpIsScalar, &gcCache);
     nx = unitLength(x);
     PROTECT(answer = allocVector(REALSXP, nx));
     for (i=0; i<nx; i++) {
-        gcontextFromgpar(currentgp, i, &gc, dd);
+        updateGContext(currentgp, i, &gc, dd, gpIsScalar, &gcCache);
         TOunit = INTEGER(unitto)[i % LENGTH(unitto)];
         FROMaxis = INTEGER(whatfrom)[0];
         TOaxis = INTEGER(whatto)[0];
@@ -3691,8 +3693,9 @@ SEXP L_locnBounds(SEXP x, SEXP y, SEXP theta)
     double *xx, *yy;
     double vpWidthCM, vpHeightCM;
     double rotationAngle;
+    int gpIsScalar[15] = {-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1};
     LViewportContext vpc;
-    R_GE_gcontext gc;
+    R_GE_gcontext gc, gcCache;
     LTransform transform;
     SEXP currentvp, currentgp;
     SEXP result = R_NilValue;
@@ -3711,6 +3714,7 @@ SEXP L_locnBounds(SEXP x, SEXP y, SEXP theta)
 			 &vpWidthCM, &vpHeightCM, 
 			 transform, &rotationAngle);
     getViewportContext(currentvp, &vpc);
+    initGContext(currentgp, &gc, dd, gpIsScalar, &gcCache);
     nx = unitLength(x); 
     ny = unitLength(y);
     if (ny > nx) 
@@ -3721,7 +3725,7 @@ SEXP L_locnBounds(SEXP x, SEXP y, SEXP theta)
 	xx = (double *) R_alloc(nx, sizeof(double));
 	yy = (double *) R_alloc(nx, sizeof(double));
 	for (i=0; i<nx; i++) {
-	    gcontextFromgpar(currentgp, i, &gc, dd);
+	    updateGContext(currentgp, i, &gc, dd, gpIsScalar, &gcCache);
 	    xx[i] = transformXtoINCHES(x, i, vpc, &gc,
 				       vpWidthCM, vpHeightCM, 
 				       dd);

--- a/src/grid.c
+++ b/src/grid.c
@@ -1924,9 +1924,10 @@ SEXP L_lines(SEXP x, SEXP y, SEXP index, SEXP arrow)
     double xold, yold;
     double vpWidthCM, vpHeightCM;
     double rotationAngle;
+    int gpIsScalar[15] = {-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1};
     const void *vmax;
     LViewportContext vpc;
-    R_GE_gcontext gc;
+    R_GE_gcontext gc, gcCache;
     LTransform transform;
     SEXP currentvp, currentgp;
     /* Get the current device 
@@ -1938,6 +1939,7 @@ SEXP L_lines(SEXP x, SEXP y, SEXP index, SEXP arrow)
 			 &vpWidthCM, &vpHeightCM, 
 			 transform, &rotationAngle);
     getViewportContext(currentvp, &vpc);
+    initGContext(currentgp, &gc, dd, gpIsScalar, &gcCache);
     GEMode(1, dd);
     /* 
      * Number of lines 
@@ -1945,7 +1947,7 @@ SEXP L_lines(SEXP x, SEXP y, SEXP index, SEXP arrow)
     nl = LENGTH(index);
     for (j=0; j<nl; j++) {
 	SEXP indices = VECTOR_ELT(index, j);
-	gcontextFromgpar(currentgp, j, &gc, dd);
+        updateGContext(currentgp, j, &gc, dd, gpIsScalar, &gcCache);
 	/* 
 	 * Number of vertices
 	 *
@@ -2021,8 +2023,9 @@ SEXP gridXspline(SEXP x, SEXP y, SEXP s, SEXP o, SEXP a, SEXP rep, SEXP index,
     double *xx, *yy, *ss;
     double vpWidthCM, vpHeightCM;
     double rotationAngle;
+    int gpIsScalar[15] = {-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1};
     LViewportContext vpc;
-    R_GE_gcontext gc;
+    R_GE_gcontext gc, gcCache;
     LTransform transform;
     SEXP currentvp, currentgp;
     SEXP tracePts = R_NilValue;
@@ -2041,7 +2044,7 @@ SEXP gridXspline(SEXP x, SEXP y, SEXP s, SEXP o, SEXP a, SEXP rep, SEXP index,
 			 &vpWidthCM, &vpHeightCM, 
 			 transform, &rotationAngle);
     getViewportContext(currentvp, &vpc);
-    gcontextFromgpar(currentgp, 0, &gc, dd);
+    initGContext(currentgp, &gc, dd, gpIsScalar, &gcCache);
     /* 
      * Number of xsplines
      */
@@ -2052,7 +2055,7 @@ SEXP gridXspline(SEXP x, SEXP y, SEXP s, SEXP o, SEXP a, SEXP rep, SEXP index,
 	const void *vmax;
 	SEXP indices = VECTOR_ELT(index, i);
 	SEXP points;
-	gcontextFromgpar(currentgp, i, &gc, dd);
+	updateGContext(currentgp, i, &gc, dd, gpIsScalar, &gcCache);
 	/* 
 	 * Number of vertices
 	 *
@@ -2463,8 +2466,9 @@ SEXP L_polygon(SEXP x, SEXP y, SEXP index)
     double xold, yold;
     double vpWidthCM, vpHeightCM;
     double rotationAngle;
+    int gpIsScalar[15] = {-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1};
     LViewportContext vpc;
-    R_GE_gcontext gc;
+    R_GE_gcontext gc, gcCache;
     LTransform transform;
     SEXP currentvp, currentgp;
     /* Get the current device 
@@ -2476,6 +2480,7 @@ SEXP L_polygon(SEXP x, SEXP y, SEXP index)
 			 &vpWidthCM, &vpHeightCM, 
 			 transform, &rotationAngle);
     getViewportContext(currentvp, &vpc);
+    initGContext(currentgp, &gc, dd, gpIsScalar, &gcCache);
     GEMode(1, dd);
     /* 
      * Number of polygons 
@@ -2484,7 +2489,7 @@ SEXP L_polygon(SEXP x, SEXP y, SEXP index)
     for (i=0; i<np; i++) {
 	const void *vmax;
 	SEXP indices = VECTOR_ELT(index, i);
-	gcontextFromgpar(currentgp, i, &gc, dd);
+	updateGContext(currentgp, i, &gc, dd, gpIsScalar, &gcCache);
 	/* 
 	 * Number of vertices
 	 *
@@ -2536,8 +2541,9 @@ static SEXP gridCircle(SEXP x, SEXP y, SEXP r,
     double xx, yy, rr1, rr2, rr = 0.0 /* -Wall */;
     double vpWidthCM, vpHeightCM;
     double rotationAngle;
+    int gpIsScalar[15] = {-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1};
     LViewportContext vpc;
-    R_GE_gcontext gc;
+    R_GE_gcontext gc, gcCache;
     LTransform transform;
     SEXP currentvp, currentgp;
     SEXP result = R_NilValue;
@@ -2555,6 +2561,7 @@ static SEXP gridCircle(SEXP x, SEXP y, SEXP r,
 			 &vpWidthCM, &vpHeightCM, 
 			 transform, &rotationAngle);
     getViewportContext(currentvp, &vpc);
+    initGContext(currentgp, &gc, dd, gpIsScalar, &gcCache);
     nx = unitLength(x); 
     ny = unitLength(y);
     nr = unitLength(r);
@@ -2567,7 +2574,7 @@ static SEXP gridCircle(SEXP x, SEXP y, SEXP r,
     }
     ncirc = 0;
     for (i=0; i<nx; i++) {
-	gcontextFromgpar(currentgp, i, &gc, dd);
+        updateGContext(currentgp, i, &gc, dd, gpIsScalar, &gcCache);
 	/*
 	 * If drawing, convert to INCHES on device
 	 * If just calculating bounds, convert to INCHES within current vp
@@ -2681,9 +2688,10 @@ static SEXP gridRect(SEXP x, SEXP y, SEXP w, SEXP h,
     double xx, yy, ww, hh;
     double vpWidthCM, vpHeightCM;
     double rotationAngle;
+    int gpIsScalar[15] = {-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1};
     int i, ny, nw, nh, maxn, nrect;
     LViewportContext vpc;
-    R_GE_gcontext gc;
+    R_GE_gcontext gc, gcCache;
     LTransform transform;
     SEXP currentvp, currentgp;
     SEXP result = R_NilValue;
@@ -2701,6 +2709,7 @@ static SEXP gridRect(SEXP x, SEXP y, SEXP w, SEXP h,
 			 &vpWidthCM, &vpHeightCM, 
 			 transform, &rotationAngle);
     getViewportContext(currentvp, &vpc);
+    initGContext(currentgp, &gc, dd, gpIsScalar, &gcCache);
     maxn = unitLength(x); 
     ny = unitLength(y); 
     nw = unitLength(w); 
@@ -2716,7 +2725,7 @@ static SEXP gridRect(SEXP x, SEXP y, SEXP w, SEXP h,
     }
     nrect = 0;
     for (i=0; i<maxn; i++) {
-	gcontextFromgpar(currentgp, i, &gc, dd);
+        updateGContext(currentgp, i, &gc, dd, gpIsScalar, &gcCache);
 	/*
 	 * If drawing, convert to INCHES on device
 	 * If just calculating bounds, convert to INCHES within current vp
@@ -2913,8 +2922,9 @@ SEXP L_path(SEXP x, SEXP y, SEXP index, SEXP rule)
     const void *vmax;
     double vpWidthCM, vpHeightCM;
     double rotationAngle;
+    int gpIsScalar[15] = {-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1};
     LViewportContext vpc;
-    R_GE_gcontext gc;
+    R_GE_gcontext gc, gcCache;
     LTransform transform;
     SEXP currentvp, currentgp;
     /* Get the current device 
@@ -2926,6 +2936,7 @@ SEXP L_path(SEXP x, SEXP y, SEXP index, SEXP rule)
 			 &vpWidthCM, &vpHeightCM, 
 			 transform, &rotationAngle);
     getViewportContext(currentvp, &vpc);
+    initGContext(currentgp, &gc, dd, gpIsScalar, &gcCache);
     GEMode(1, dd);
     /*
      * Iterate over all paths
@@ -2969,7 +2980,7 @@ SEXP L_path(SEXP x, SEXP y, SEXP index, SEXP rule)
                 k++;
             }
     	}
-    	gcontextFromgpar(currentgp, h, &gc, dd);
+    	updateGContext(currentgp, h, &gc, dd, gpIsScalar, &gcCache);
     	GEPath(xx, yy, npoly, nper, INTEGER(rule)[0], &gc, dd);
     	vmaxset(vmax);
     }
@@ -2989,8 +3000,9 @@ SEXP L_raster(SEXP raster, SEXP x, SEXP y, SEXP w, SEXP h,
     double xx, yy, ww, hh;
     double vpWidthCM, vpHeightCM;
     double rotationAngle;
+    int gpIsScalar[15] = {-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1};
     LViewportContext vpc;
-    R_GE_gcontext gc;
+    R_GE_gcontext gc, gcCache;
     LTransform transform;
     SEXP currentvp, currentgp;
     SEXP dim;
@@ -3004,6 +3016,7 @@ SEXP L_raster(SEXP raster, SEXP x, SEXP y, SEXP w, SEXP h,
 			 &vpWidthCM, &vpHeightCM, 
 			 transform, &rotationAngle);
     getViewportContext(currentvp, &vpc);
+    initGContext(currentgp, &gc, dd, gpIsScalar, &gcCache);
     /* Convert the raster matrix to R internal colours */
     n = LENGTH(raster);
     if (n <= 0) {
@@ -3033,7 +3046,7 @@ SEXP L_raster(SEXP raster, SEXP x, SEXP y, SEXP w, SEXP h,
 	maxn = nh;
     GEMode(1, dd);
     for (i=0; i<maxn; i++) {
-        gcontextFromgpar(currentgp, i, &gc, dd);
+        updateGContext(currentgp, i, &gc, dd, gpIsScalar, &gcCache);
         transformLocn(x, y, i, vpc, &gc,
                       vpWidthCM, vpHeightCM,
                       dd,
@@ -3155,8 +3168,9 @@ static SEXP gridText(SEXP label, SEXP x, SEXP y, SEXP hjust, SEXP vjust,
     double *xx, *yy;
     double vpWidthCM, vpHeightCM;
     double rotationAngle;
+    int gpIsScalar[15] = {-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1};
     LViewportContext vpc;
-    R_GE_gcontext gc;
+    R_GE_gcontext gc, gcCache;
     LTransform transform;
     SEXP txt, result = R_NilValue;
     double edgex, edgey;
@@ -3183,6 +3197,7 @@ static SEXP gridText(SEXP label, SEXP x, SEXP y, SEXP hjust, SEXP vjust,
 			 &vpWidthCM, &vpHeightCM, 
 			 transform, &rotationAngle);
     getViewportContext(currentvp, &vpc);
+    initGContext(currentgp, &gc, dd, gpIsScalar, &gcCache);
     nx = unitLength(x); 
     ny = unitLength(y);
     if (ny > nx) 
@@ -3191,7 +3206,7 @@ static SEXP gridText(SEXP label, SEXP x, SEXP y, SEXP hjust, SEXP vjust,
     xx = (double *) R_alloc(nx, sizeof(double));
     yy = (double *) R_alloc(nx, sizeof(double));
     for (i=0; i<nx; i++) {
-	gcontextFromgpar(currentgp, i, &gc, dd);
+        updateGContext(currentgp, i, &gc, dd, gpIsScalar, &gcCache);
 	/*
 	 * If drawing, convert to INCHES on device
 	 * If just calculating bounds, convert to INCHES within current vp
@@ -3236,7 +3251,7 @@ static SEXP gridText(SEXP label, SEXP x, SEXP y, SEXP hjust, SEXP vjust,
 	}
 	for (i=0; i<nx; i++) {
 	    int doDrawing = 1;
-	    gcontextFromgpar(currentgp, i, &gc, dd);
+	    updateGContext(currentgp, i, &gc, dd, gpIsScalar, &gcCache);
 	    /* 
 	     * Generate bounding boxes when checking for overlap
 	     * or sizing text
@@ -3268,7 +3283,7 @@ static SEXP gridText(SEXP label, SEXP x, SEXP y, SEXP hjust, SEXP vjust,
 		xx[i] = toDeviceX(xx[i], GE_INCHES, dd);
 		yy[i] = toDeviceY(yy[i], GE_INCHES, dd);
 		if (R_FINITE(xx[i]) && R_FINITE(yy[i])) {
-		    gcontextFromgpar(currentgp, i, &gc, dd);
+		    updateGContext(currentgp, i, &gc, dd, gpIsScalar, &gcCache);
 		    if (isExpression(txt))
 			GEMathText(xx[i], yy[i],
 				   VECTOR_ELT(txt, i % LENGTH(txt)),
@@ -3759,8 +3774,9 @@ SEXP L_stringMetric(SEXP label)
     int i, n;
     double vpWidthCM, vpHeightCM;
     double rotationAngle;
+    int gpIsScalar[15] = {-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1};
     LViewportContext vpc;
-    R_GE_gcontext gc;
+    R_GE_gcontext gc, gcCache;
     LTransform transform;
     SEXP currentvp, currentgp;
     SEXP txt;
@@ -3779,6 +3795,7 @@ SEXP L_stringMetric(SEXP label)
 			 &vpWidthCM, &vpHeightCM, 
 			 transform, &rotationAngle);
     getViewportContext(currentvp, &vpc);
+    initGContext(currentgp, &gc, dd, gpIsScalar, &gcCache);
     /* The label can be a string or an expression: is protected.
      */
     txt = label;
@@ -3794,7 +3811,7 @@ SEXP L_stringMetric(SEXP label)
     PROTECT(width = allocVector(REALSXP, n));
     if (n > 0) {
 	for (i=0; i<n; i++) {
-	    gcontextFromgpar(currentgp, i, &gc, dd);
+	    updateGContext(currentgp, i, &gc, dd, gpIsScalar, &gcCache);
             if (isExpression(txt))
                 GEExpressionMetric(VECTOR_ELT(txt, i % LENGTH(txt)), &gc, 
                                    &asc, &dsc, &wid,


### PR DESCRIPTION
This PR is a continuation of #8 and #10 implementing the graphic parameter caching approach for the remaining graphic primitives.

A couple of notes:
- This PR also fix a regression introduced by #8, when the size of points were given in string relative units
- The changes ignores `L_arrows` as it is defunct AFAIK, and should probably just be deleted (but outside of scope for this PR)
- Both `L_rect` and `L_circle` could benefit from the same changes as done to L_point to avoid needless reconversion of the provided units, but as these grobs are unlikely to be called with thousands of individual shapes, I gather the speed improvements are not worth the added complexity