### PR TITLE
Guard against old unit objects

### DIFF
--- a/R/unit.R
+++ b/R/unit.R
@@ -269,6 +269,7 @@ Ops.unit <- function(e1, e2) {
       	e1 <- -as.vector(e1)
       	attributes(e1) <- attr
       } else {
+        is.unit(e1)  # guard against old unit
       	e1 <- .Call(C_flipUnits, e1)
       }
     }
@@ -294,6 +295,7 @@ Ops.unit <- function(e1, e2) {
   		unit <- value * as.vector(unit)
   		attributes(unit) <- attr
   	} else {
+  	    is.unit(e1)  # guard against old unit
   		unit <- .Call(C_multUnits, unit, value)
   	}
   	return(unit)

--- a/src/unit.c
+++ b/src/unit.c
@@ -1778,8 +1778,7 @@ SEXP multUnit(SEXP unit, double value) {
 	return mult;
 }
 SEXP multUnits(SEXP units, SEXP values) {
-    if (!inherits(units, "unit_v2")) error(_("old version of unit class is no longer allowed"));
-	int nValues = LENGTH(values);
+    int nValues = LENGTH(values);
 	int n = LENGTH(units) < nValues ? nValues : LENGTH(units);
 	SEXP multiplied = PROTECT(allocVector(VECSXP, n));
 	double *pValues = REAL(values);
@@ -1864,10 +1863,7 @@ SEXP addUnit(SEXP u1, SEXP u2) {
 	return result;
 }
 SEXP addUnits(SEXP u1, SEXP u2) {
-    if (!inherits(u1, "unit_v2") || !inherits(u2, "unit_v2")) {
-        error(_("old version of unit class is no longer allowed"));
-    }
-	int n = LENGTH(u1) < LENGTH(u2) ? LENGTH(u2) : LENGTH(u1);
+    int n = LENGTH(u1) < LENGTH(u2) ? LENGTH(u2) : LENGTH(u1);
 	SEXP added = PROTECT(allocVector(VECSXP, n));
 	for (int i = 0; i < n; i++) {
 		SEXP unit1 = PROTECT(unitScalar(u1, i));


### PR DESCRIPTION
@pmur002 this is my proposal for better errors when using old-style units with the new implementation. Rather than trying to detect specific instances of the old units I've elected to instead have the new unit class include a `unit_v2` class at the top. `is.unit()` now checks for inheritance of `unit_v2` and throws an error if an object inherits from `unit` but not `unit_v2`

I've also made changes to the functions that doesn't call `is.unit()`, some at the R level and some at the C level, to make sure that every call into the unit functionality is validated.

What do you think of this approach?