### PR TITLE
POC on L_points for optimising unit conversion in simpleUnits

### DIFF
--- a/src/grid.c
+++ b/src/grid.c
@@ -3453,18 +3453,19 @@ SEXP L_points(SEXP x, SEXP y, SEXP pch, SEXP size)
     vmax = vmaxget();
     xx = (double *) R_alloc(nx, sizeof(double));
     yy = (double *) R_alloc(nx, sizeof(double));
-    for (i=0; i<nx; i++) {
-	updateGContext(currentgp, i, &gc, dd, gpIsScalar, &gcCache);
-	transformLocn(x, y, i, vpc, &gc,
-		      vpWidthCM, vpHeightCM,
-		      dd,
-		      transform,
-		      &(xx[i]), &(yy[i]));
-	/* The graphics engine only takes device coordinates
-	 */
-	xx[i] = toDeviceX(xx[i], GE_INCHES, dd);
-	yy[i] = toDeviceY(yy[i], GE_INCHES, dd);
-    }
+    transformAllLoc(x, y, 0, nx, xx, yy, currentgp, &gc, dd, gpIsScalar, &gcCache, vpc, vpWidthCM, vpHeightCM, transform);
+    //for (i=0; i<nx; i++) {
+	//updateGContext(currentgp, i, &gc, dd, gpIsScalar, &gcCache);
+	//transformLocn(x, y, i, vpc, &gc,
+	//	      vpWidthCM, vpHeightCM,
+	//	      dd,
+	//	      transform,
+	//	      &(xx[i]), &(yy[i]));
+	///* The graphics engine only takes device coordinates
+	// */
+	//xx[i] = toDeviceX(xx[i], GE_INCHES, dd);
+	//yy[i] = toDeviceY(yy[i], GE_INCHES, dd);
+    //}
     ss = (double *) R_alloc(nss, sizeof(double));
     for (i=0; i < nss; i++) {
         updateGContext(currentgp, i, &gc, dd, gpIsScalar, &gcCache);

--- a/src/grid.c
+++ b/src/grid.c
@@ -3467,12 +3467,13 @@ SEXP L_points(SEXP x, SEXP y, SEXP pch, SEXP size)
 	//yy[i] = toDeviceY(yy[i], GE_INCHES, dd);
     //}
     ss = (double *) R_alloc(nss, sizeof(double));
-    for (i=0; i < nss; i++) {
-        updateGContext(currentgp, i, &gc, dd, gpIsScalar, &gcCache);
-        ss[i] = transformWidthtoINCHES(size, i, vpc, &gc,
-                                       vpWidthCM, vpHeightCM, dd);
-        ss[i] = toDeviceWidth(ss[i], GE_INCHES, dd);
-    }
+    transformAllWidth(size, 0, nss, ss, currentgp, &gc, dd, gpIsScalar, &gcCache, vpc, vpWidthCM, vpHeightCM);
+    //for (i=0; i < nss; i++) {
+    //    updateGContext(currentgp, i, &gc, dd, gpIsScalar, &gcCache);
+    //    ss[i] = transformWidthtoINCHES(size, i, vpc, &gc,
+    //                                   vpWidthCM, vpHeightCM, dd);
+    //    ss[i] = toDeviceWidth(ss[i], GE_INCHES, dd);
+    //}
     ps = (int *) R_alloc(npch, sizeof(int));
     if (isString(pch)) pType = 0;
     else if (isInteger(pch)) pType = 1;

--- a/src/grid.h
+++ b/src/grid.h
@@ -447,6 +447,11 @@ double transformXYfromNPC(double x, int to, double min, double max);
 
 double transformWHfromNPC(double x, int to, double min, double max);
 
+void transformAllLoc(SEXP x, SEXP y, int from, int to, double* xx, double* yy,
+                     SEXP gp, const pGEcontext gc, pGEDevDesc dd, int* gpIsScalar,
+                     const pGEcontext gcCache, LViewportContext vpc, 
+                     double vpWidthCM, double vpHeightCM, LTransform transform);
+
 /* From just.c */
 double justifyX(double x, double width, double hjust);
 

--- a/src/grid.h
+++ b/src/grid.h
@@ -452,6 +452,16 @@ void transformAllLoc(SEXP x, SEXP y, int from, int to, double* xx, double* yy,
                      const pGEcontext gcCache, LViewportContext vpc, 
                      double vpWidthCM, double vpHeightCM, LTransform transform);
 
+void transformAllWidth(SEXP x, int from, int to, double* xx,
+                       SEXP gp, const pGEcontext gc, pGEDevDesc dd, int* gpIsScalar,
+                       const pGEcontext gcCache, LViewportContext vpc, 
+                       double vpWidthCM, double vpHeightCM);
+
+void transformAllHeight(SEXP x, int from, int to, double* xx,
+                        SEXP gp, const pGEcontext gc, pGEDevDesc dd, int* gpIsScalar,
+                        const pGEcontext gcCache, LViewportContext vpc, 
+                        double vpWidthCM, double vpHeightCM);
+
 /* From just.c */
 double justifyX(double x, double width, double hjust);
 

--- a/src/unit.c
+++ b/src/unit.c
@@ -2048,3 +2048,65 @@ void transformAllLoc(SEXP x, SEXP y, int from, int to, double* xx, double* yy,
         j++;
     }
 } 
+void transformAllWidth(SEXP x, int from, int to, double* xx,
+                     SEXP gp, const pGEcontext gc, pGEDevDesc dd, int* gpIsScalar,
+                     const pGEcontext gcCache, LViewportContext vpc, 
+                     double vpWidthCM, double vpHeightCM) {
+    int j = 0;
+    if (isSimpleUnit(x)) {
+        double xFacZero, xFacOne, xFacDiff;
+        SEXP zeroX = unit(0.0, unitUnit(x, 0));
+        SEXP oneX = unit(1.0, unitUnit(x, 0));
+        xFacZero = transformWidthtoINCHES(zeroX, 0, vpc, gc, vpWidthCM, 
+                                          vpHeightCM, dd);
+        xFacZero = toDeviceWidth(xFacZero, GE_INCHES, dd);
+        xFacOne = transformWidthtoINCHES(oneX, 0, vpc, gc, vpWidthCM, 
+                                         vpHeightCM, dd);
+        xFacOne = toDeviceWidth(xFacOne, GE_INCHES, dd);
+        
+        xFacDiff = xFacOne - xFacZero;
+        
+        for (int i = from; i < to; i++) {
+            xx[j] = REAL(x)[i] * xFacDiff + xFacZero;
+            j++;
+        }
+        return;
+    }
+    
+    for (int i = from; i < to; i++) {
+        updateGContext(gp, i, gc, dd, gpIsScalar, gcCache);
+        xx[i] = transformWidthtoINCHES(x, i, vpc, gc, vpWidthCM, vpHeightCM, dd);
+        xx[i] = toDeviceWidth(xx[i], GE_INCHES, dd);
+    }
+}
+void transformAllHeight(SEXP x, int from, int to, double* xx,
+                        SEXP gp, const pGEcontext gc, pGEDevDesc dd, int* gpIsScalar,
+                        const pGEcontext gcCache, LViewportContext vpc, 
+                        double vpWidthCM, double vpHeightCM) {
+    int j = 0;
+    if (isSimpleUnit(x)) {
+        double xFacZero, xFacOne, xFacDiff;
+        SEXP zeroX = unit(0.0, unitUnit(x, 0));
+        SEXP oneX = unit(1.0, unitUnit(x, 0));
+        xFacZero = transformHeighttoINCHES(zeroX, 0, vpc, gc, vpWidthCM, 
+                                           vpHeightCM, dd);
+        xFacZero = toDeviceHeight(xFacZero, GE_INCHES, dd);
+        xFacOne = transformHeighttoINCHES(oneX, 0, vpc, gc, vpWidthCM, 
+                                          vpHeightCM, dd);
+        xFacOne = toDeviceHeight(xFacOne, GE_INCHES, dd);
+        
+        xFacDiff = xFacOne - xFacZero;
+        
+        for (int i = from; i < to; i++) {
+            xx[j] = REAL(x)[i] * xFacDiff + xFacZero;
+            j++;
+        }
+        return;
+    }
+    
+    for (int i = from; i < to; i++) {
+        updateGContext(gp, i, gc, dd, gpIsScalar, gcCache);
+        xx[i] = transformHeighttoINCHES(x, i, vpc, gc, vpWidthCM, vpHeightCM, dd);
+        xx[i] = toDeviceHeight(xx[i], GE_INCHES, dd);
+    }
+}


### PR DESCRIPTION
This PR provides a first stab at factoring out the unit conversion of the input positions during grob drawing. The POC has been done on L_points.

Basic approach is to check whether both x and y are simpleUnit vectors. If so, a conversion factor is calculated once and applied to the whole vector. If either of the vectors are not simpleUnit objects it will fall back to the standard element-wise conversion.

The same approach should be applicable for converting widths and heights but it is not implemented yet.

One thing to consider is that a few unit types are dependent on gpar settings, so even in the case of simpleUnit vectors we need to make sure that e.g. line height is constant over the whole vector. 

Preliminary testing gives >10x speedup in `grid.points()` with 1e5 points, which is insane and actually makes `grid.points()` faster than `points()`

@pmur002 can you have a look at this POC and maybe identify some wrong assumptions I may have made before I try to apply it to all the grobs