### PR TITLE
make sure amount is expanded to the length of the summary units

### DIFF
--- a/R/unit.R
+++ b/R/unit.R
@@ -311,6 +311,7 @@ Summary.unit <- function(..., na.rm=FALSE) {
     if (nMatches != 0) {
         data <- lapply(x, .subset2, 2L)
         amount <- vapply(x, .subset2, numeric(1), 1L)[matchUnits]
+        amount <- rep(amount, lengths(data[matchUnits]))
         matchData <- unclass(unlist(data[matchUnits], recursive = FALSE))
         for (i in seq_along(amount)) {
             if (amount[i] != 1) 


### PR DESCRIPTION
This fixes the bug reported here: https://stat.ethz.ch/pipermail/r-devel/2020-April/079388.html

@pmur002 can I get you to patch this?